### PR TITLE
feat: unified Strongholds toolbar button + reference Foundry API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,8 @@ build/
 .env
 .env.local
 
+# Local OpenAI CLI config (contains secrets)
+.openai/config.json
+
 # PDF documentation (too large for git)
 *.pdf

--- a/.openai/config.json.example
+++ b/.openai/config.json.example
@@ -1,0 +1,11 @@
+{
+  // Configuration for OpenAI CLI codex commands
+  // See https://github.com/openai/openai-cli for details
+  "model": "gpt-5",
+  // Fill in your own overrides below and save as .openai/config.json (ignored by git):
+  // "temperature": 0.7,
+  // "max_tokens": 1024,
+  // "organization": "org-...",
+  // "api_key": "YOUR_API_KEY",
+  // "api_base": "https://api.openai.com/v1"
+}

--- a/docs/DOCUMENT_BIBLE.md
+++ b/docs/DOCUMENT_BIBLE.md
@@ -1,0 +1,50 @@
+# Project Bible: Strongholds & Followers
+
+This document serves as the single source of truth (“bible”) for AI agents and developers working on the Strongholds & Followers FoundryVTT module. It defines the project’s objectives, vision, architecture, and core components to ensure alignment and clarity.
+
+## 1. Objectives
+1. **Empower Game Masters**: Provide GMs with a robust interface to create, configure, and manage party strongholds (Temple, Keep, Tower, Establishment).
+2. **Enhance Player Experience**: Enable players to view active strongholds and automatically receive thematic bonuses during extended rests.
+3. **Automate Bonus Application**: Seamlessly deliver class‑specific and level‑based bonuses through D&D 5e system hooks.
+4. **Maintain Extensibility**: Design with clear API and modular patterns so future features (new stronghold types, alternative systems) can be added easily.
+5. **Follow Best Practices**: Adhere to FoundryVTT public API, security guidelines, and performance optimizations (debouncing, batch updates).
+
+## 2. Vision
+> “Strongholds & Followers should feel like a natural extension of D&D 5e: easy for GMs to manage infrastructures, engaging for players to explore strategic benefits, and invisible overhead to the core gameplay experience.”
+
+## 3. Architecture Overview
+```text
+strongholds-and-followers/
+├── module.json               # Manifest for Foundry registration and compatibility
+├── scripts/
+│   ├── main.js               # Initialization, hooks, settings, and API exposure
+│   ├── stronghold-data.js    # Static data and business logic for stronghold types and costs
+│   ├── stronghold-manager.js # GM Application (UI and data management)
+│   └── stronghold-viewer.js  # Player Application (UI for viewing active strongholds)
+├── templates/                # Handlebars templates for UI applications
+├── styles/                   # CSS leveraging Foundry theme variables
+├── lang/                     # Localization files
+└── docs/                     # Documentation and this Project Bible
+```
+
+### 3.1 Core Components
+- **StrongholdData**: Defines types, level costs, and bonus structures in a static class.
+- **StrongholdManager**: Extends Legacy Application to allow GMs to create, activate, and upgrade strongholds.
+- **StrongholdViewer**: Provides a read‑only interface for players to inspect active strongholds and bonuses.
+- **main.js**: Registers settings, API (`game.strongholds.*`), Handlebars helpers, and hooks (scene controls, player list, D&D 5e rest hook).
+
+## 4. Data Flow & Hooks
+1. GM clicks scene-control button → `StrongholdManager.render(true)` → user input → `game.settings.set('strongholds', data)`
+2. Player clicks player-list button → `StrongholdViewer.render(true)` → reads `game.settings.get('strongholds')`
+3. On `dnd5e.restCompleted` (long rest) → if auto‑apply enabled, generates whispered chat message with applicable bonuses.
+
+## 5. Extension Points
+- **New Stronghold Types**: Add entries in `STRONGHOLD_TYPES` and `STRONGHOLD_COSTS`.
+- **Additional Hooks**: Tie into other system events (e.g., short rest hooks, spell-casting hooks).
+- **Alternate Systems**: Detect `game.system.id` and adapt property paths for different RPG systems.
+
+## 6. Development & Maintenance
+- Update this Project Bible when any core objective, vision statement, or architecture changes.
+- Use it as the authoritative guide for code reviews and AI‑driven development tasks.
+
+*Last updated: $(date +"%Y-%m-%d").*

--- a/docs/FOUNDRY_QUICK_REFERENCE.md
+++ b/docs/FOUNDRY_QUICK_REFERENCE.md
@@ -67,6 +67,10 @@ await game.settings.set('module-name', 'setting-key', newValue);
 Hooks.once('init', () => {});
 Hooks.once('ready', () => {});
 
+// Scene Controls Toolbar: customize left toolbar buttons
+// Reference: https://foundryvtt.com/api/Hooks.html#getSceneControlButtons
+Hooks.on('getSceneControlButtons', (controls) => {});
+
 // Document operations
 Hooks.on('createActor', (actor, options, userId) => {});
 Hooks.on('updateActor', (actor, updateData, options, userId) => {});

--- a/docs/MODULE_PATTERNS.md
+++ b/docs/MODULE_PATTERNS.md
@@ -62,9 +62,23 @@ Hooks.once('init', async function() {
         name: 'Automatically Apply Bonuses',
         hint: 'Automatically apply stronghold bonuses when players take extended rests',
         scope: 'world',    // GM controls this
-        config: true,      // Show in settings UI  
+        config: true,      // Show in settings UI
         type: Boolean,
         default: true
+    });
+
+    // Configure Settings menu button in header
+    game.settings.registerMenu('strongholds-and-followers', 'manageStrongholds', {
+        name: 'Manage Strongholds',
+        hint: 'Open Strongholds Manager/Viewer',
+        icon: 'fas fa-castle',
+        type: class {
+            constructor() {
+                if (game.user.isGM) new StrongholdManager().render(true);
+                else new StrongholdViewer().render(true);
+            }
+        },
+        restricted: false
     });
 });
 ```

--- a/docs/MODULE_PATTERNS.md
+++ b/docs/MODULE_PATTERNS.md
@@ -175,6 +175,8 @@ Hooks.on('dnd5e.restCompleted', async (actor, data) => {
         whisper: [game.user.id]  // Private message to player
     });
 });
+
+> **Reference**: See the Foundry API for scene controls: https://foundryvtt.com/api/Hooks.html#getSceneControlButtons
 ```
 
 ## 📊 **Data Management Patterns**

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,9 @@ This directory contains comprehensive documentation for AI agents and developers
 - Event handling best practices
 - Styling with Foundry CSS variables
 
+### **[DOCUMENT_BIBLE.md](./DOCUMENT_BIBLE.md)**
+**Authoritative project “bible” with objectives, vision, and architecture overview**
+
 ## 🎯 **How to Use This Documentation**
 
 ### **For AI Agents**

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -42,6 +42,20 @@ Hooks.once('init', async function() {
         default: true
     });
 
+    // Add a Configure Settings menu button in the header to open Strongholds (GM or Player view)
+    game.settings.registerMenu('strongholds-and-followers', 'manageStrongholds', {
+        name: 'Manage Strongholds',
+        hint: 'Open the Strongholds management/viewer window',
+        icon: 'fas fa-castle',
+        type: class {
+            constructor() {
+                if (game.user.isGM) new StrongholdManager().render(true);
+                else new StrongholdViewer().render(true);
+            }
+        },
+        restricted: false
+    });
+
     game.strongholds = {
         StrongholdManager,
         StrongholdViewer,

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -61,43 +61,27 @@ Hooks.once('ready', async function() {
     }
     
     if (game.user.isGM) {
-        ui.notifications.info("Strongholds & Followers module loaded. Use the 'Manage Strongholds' button in the scene controls.");
+        ui.notifications.info("Strongholds & Followers module loaded. Click the 'Strongholds' button in the scene controls toolbar.");
     }
 });
 
 Hooks.on('getSceneControlButtons', (controls) => {
-    if (!game.user.isGM) return;
-    
+    // Add a Strongholds toolbar button for both GM (manager) and players (viewer)
     const tokenControls = controls.find(c => c.name === 'token');
-    if (tokenControls) {
-        tokenControls.tools.push({
-            name: 'strongholds',
-            title: 'Manage Strongholds',
-            icon: 'fas fa-castle',
-            button: true,
-            onClick: () => {
-                new StrongholdManager().render(true);
-            }
-        });
-    }
+    if (!tokenControls) return;
+    tokenControls.tools.push({
+        name: 'strongholds',
+        title: 'Strongholds',
+        icon: 'fas fa-castle',
+        button: true,
+        onClick: () => {
+            if (game.user.isGM) new StrongholdManager().render(true);
+            else new StrongholdViewer().render(true);
+        }
+    });
 });
 
-Hooks.on('renderPlayerList', (app, html, data) => {
-    if (game.user.isGM) return;
-    
-    const strongholdButton = $(`
-        <div class="strongholds-button" title="View Strongholds">
-            <i class="fas fa-castle"></i>
-            <span>Strongholds</span>
-        </div>
-    `);
-    
-    strongholdButton.on('click', () => {
-        new StrongholdViewer().render(true);
-    });
-    
-    html.append(strongholdButton);
-});
+// Remove player-list button in favor of unified toolbar button above
 
 Hooks.on('dnd5e.restCompleted', async (actor, data) => {
     if (!game.settings.get('strongholds-and-followers', 'enableAutoApplyBonuses')) return;


### PR DESCRIPTION
**What?**

- Unified toolbar button 'Strongholds' in scene controls for GM and players (opens manager/viewer accordingly).
- Removed old player-list hook.
- Updated GM notification text.
- Added references to Foundry API documentation for  in docs/MODULE_PATTERNS.md and docs/FOUNDRY_QUICK_REFERENCE.md.

Please review the code and docs updates together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified Strongholds button in scene controls for all users; GMs open a management UI, players see a read-only viewer. In-app messaging updated.

* **Documentation**
  * Added an authoritative project "bible" and updated docs index.
  * Added quick-reference guidance for scene control hooks and minor formatting fixes.

* **Chores**
  * Ignore OpenAI CLI config and all PDFs in version control.
  * Added an example OpenAI CLI config template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->